### PR TITLE
Karma version >=0.9 to be compatible with karma-jasmine dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "grunt-contrib-watch": "~0.2.0",
     "grunt-conventional-changelog": "~0.0.12",
     "karma-mocha": "~0.1.3",
-    "karma": "~0.12.0",
+    "karma": ">=0.9",
     "karma-firefox-launcher": "~0.1.3",
     "karma-chrome-launcher": "~0.1.2"
   },
   "peerDependencies": {
     "grunt": "0.4.x",
-    "karma": ">=0.13.0"
+    "karma": ">=0.9"
   }
 }


### PR DESCRIPTION
@scottydawg, 0.9 to be compatible with karma-jasmine.